### PR TITLE
Added plugin for autoformating javascript, html, css.

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -232,10 +232,11 @@ au FileType cpp nnoremap <leader>h :vsp %<.h<CR>
 au FileType cpp map <Leader>k :%pyf ~/.vim/clang-format.py<CR>
 au FileType cpp imap <C-K> <ESC>:pyf ~/.vim/clang-format.py<CR>i
 
-" javascript, html, css
+" javascript, html, css, scss
 au FileType javascript nnoremap <leader>k :call JsBeautify()<cr>
-au FileType html nnoremap <leader>k :call JsBeautify()<cr>
-au FileType css nnoremap <leader>k :call JsBeautify()<cr>
+au FileType html nnoremap <leader>k :call HtmlBeautify()<cr>
+au FileType css nnoremap <leader>k :call CSSBeautify()<cr>
+au FileType scss nnoremap <leader>k :call CSSBeautify()<cr>
 
 au FileType cpp set iskeyword-=-
 

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -38,6 +38,8 @@ Bundle 'Lokaltog/vim-easymotion'
 Plugin 'tacahiroy/ctrlp-funky'
 Plugin 'lfilho/cosco.vim'
 Plugin 'editorconfig/editorconfig-vim'
+Plugin 'maksimr/vim-jsbeautify'
+Plugin 'einars/js-beautify'
 
 " Color themes
 Plugin 'https://github.com/vim-scripts/ScrollColors'
@@ -229,6 +231,11 @@ au FileType cpp nnoremap <leader>h :vsp %<.h<CR>
 " clang-format
 au FileType cpp map <Leader>k :%pyf ~/.vim/clang-format.py<CR>
 au FileType cpp imap <C-K> <ESC>:pyf ~/.vim/clang-format.py<CR>i
+
+" javascript, html, css
+au FileType javascript nnoremap <leader>k :call JsBeautify()<cr>
+au FileType html nnoremap <leader>k :call JsBeautify()<cr>
+au FileType css nnoremap <leader>k :call JsBeautify()<cr>
 
 au FileType cpp set iskeyword-=-
 


### PR DESCRIPTION
See [js-beautify](https://github.com/beautify-web/js-beautify) and [vim-jsbeautify](https://github.com/maksimr/vim-jsbeautify) for details.
Configuration via .editorconfig. Example from [vim-jsbeautify](https://github.com/maksimr/vim-jsbeautify):

[**.js]
indent_style = space
indent_size = 4

[**.css]
indent_style = space
indent_size = 4

[**.html]
indent_style = space
indent_size = 4
max_char = 78
brace_style = expand